### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.21"
 async-trait = "0.1.53"
 tracing = "0.1.33"
 cfg-if = "1.0.0"
-compact_str = { version = "0.3.2", features = [ "serde" ] }
+compact_str = { version = "0.4", features = [ "serde" ] }
 delegate = "0.6.2"
 bytes = { version = "1", features = [ "serde" ] }
 take_mut = "0.2.2"

--- a/src/providers/addr.rs
+++ b/src/providers/addr.rs
@@ -1,7 +1,7 @@
 use crate::{err, Error};
 use crate::{Channel, Result};
 use cfg_if::cfg_if;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -46,9 +46,9 @@ pub enum Addr {
     /// Unencrypted unix provider
     InsecureUnix(Arc<PathBuf>),
     /// Websocket provider
-    Wss(Arc<CompactStr>),
+    Wss(Arc<CompactString>),
     /// Unencrypted websocket provider
-    InsecureWss(Arc<CompactStr>),
+    InsecureWss(Arc<CompactString>),
 }
 
 impl From<&Addr> for String {
@@ -148,7 +148,7 @@ impl<'de> Deserialize<'de> for Addr {
     where
         D: serde::Deserializer<'de>,
     {
-        let string: CompactStr = CompactStr::deserialize(deserializer)?;
+        let string: CompactString = CompactString::deserialize(deserializer)?;
         Addr::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
@@ -272,13 +272,13 @@ impl FromStr for Addr {
             }
             AddressType::Wss => {
                 let addr = addr
-                    .parse::<CompactStr>()
+                    .parse::<CompactString>()
                     .map_err(|e| err!(invalid_input, e))?;
                 Addr::Wss(Arc::new(addr))
             }
             AddressType::InsecureWss => {
                 let addr = addr
-                    .parse::<CompactStr>()
+                    .parse::<CompactString>()
                     .map_err(|e| err!(invalid_input, e))?;
                 Addr::InsecureWss(Arc::new(addr))
             }


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning